### PR TITLE
Eric/enemy rebalance

### DIFF
--- a/brackey-game/air.gd
+++ b/brackey-game/air.gd
@@ -3,8 +3,9 @@ extends "res://base_enemy.gd"
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	health = 70
+	health = 60
 	speed = 120
 	target = "Core"
 	tier = 2
+	droprate = 2
 	super() # Calls base class ready

--- a/brackey-game/base_enemy.gd
+++ b/brackey-game/base_enemy.gd
@@ -1,6 +1,6 @@
 extends Area2D
 signal enemy_died()
-@export var health = 100
+@export var health = 100 # Max health. Increased over time
 var current_hp = 1
 @export var target: String# Player or core
 var speed: int
@@ -30,15 +30,17 @@ func _ready() -> void:
 func elite():
 	self.scale = Vector2(2,2) #double in size
 	if tier == 3:
-		health *= 8 # Base health of 6400, about 11s to kill at max power
+		health = health * 8 # Base health of 6400, about 11s to kill at max power
+		points = points * 2 # x4 points total
 	else: # tier 1 and 2
-		health *= 8
+		health = health * 8
 	$Hp.max_value = health
 	$Hp.value = health 
 	current_hp = health
 	droprate = 1
-	points *= 2
-	speed *= 1.25 # Add 25% more speed
+	points = points * 2
+	speed = speed * 1.25 # Add 25% more speed
+	#print(health, speed)
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:

--- a/brackey-game/base_enemy.gd
+++ b/brackey-game/base_enemy.gd
@@ -13,6 +13,7 @@ var points: int # tier, x2 if elite
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	$AnimatedSprite2D.play()
+	health += Global.hp_bonus
 	$Hp.max_value = health
 	$Hp.value = health
 	speed += Global.spd_bonus
@@ -29,15 +30,15 @@ func _ready() -> void:
 func elite():
 	self.scale = Vector2(2,2) #double in size
 	if tier == 3:
-		health *= 5
+		health *= 8 # Base health of 6400, about 11s to kill at max power
 	else: # tier 1 and 2
-		health *= 4
+		health *= 8
 	$Hp.max_value = health
 	$Hp.value = health 
 	current_hp = health
 	droprate = 1
 	points *= 2
-	speed += 10 # Add small speed bonus
+	speed *= 1.25 # Add 25% more speed
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:

--- a/brackey-game/charge_enemy.gd
+++ b/brackey-game/charge_enemy.gd
@@ -1,10 +1,10 @@
 extends "res://base_enemy.gd"
 
 var CHARGE_WARMUP = 1
-var CHARGE_COOLDOWN = 3
+var CHARGE_COOLDOWN = 4
 var CHARGE_SPEED = 800
-var CHARGE_DURATION = 0.33
-var BASE_SPEED = 20
+var CHARGE_DURATION = 0.4
+var BASE_SPEED = 40
 var charge_direction
 var can_charge = true
 var is_charging = false
@@ -18,6 +18,8 @@ func _ready() -> void:
 	droprate = 1
 	tier = 3
 	super()
+	# Revert charge range being doubled
+	$TargetRange/TargetRangeDetection.scale = Vector2(1,1)
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
@@ -48,8 +50,7 @@ func pathing(delta):
 						return
 	else: #otherwise execute charge - speed is 0 or CHARGE_SPEED depending on stage of cast
 		position += charge_direction * speed * delta
-		
-		
+
 		
 
 func _on_charge_timer_timeout() -> void:

--- a/brackey-game/demon.gd
+++ b/brackey-game/demon.gd
@@ -3,9 +3,10 @@ extends "res://base_enemy.gd"
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	health = 90
-	speed = 80
+	health = 100
+	speed = 70
 	target = "Core"
 	drops = "red"
 	tier = 2
+	droprate = 2
 	super()

--- a/brackey-game/genie.gd
+++ b/brackey-game/genie.gd
@@ -3,9 +3,10 @@ extends "res://base_enemy.gd"
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	health = 70
+	health = 90
 	speed = 60
 	target = "Player"
 	drops = "blue"
 	tier = 2
+	droprate = 2
 	super()

--- a/brackey-game/global.gd
+++ b/brackey-game/global.gd
@@ -37,7 +37,7 @@ var blue: int
 
 # Difficulty
 var elite_chance: int
-var hp_bonus: int # Not used
+var hp_bonus: int
 var spd_bonus: int
 
 # Modifiers - not used
@@ -66,6 +66,7 @@ func _ready() -> void:
 
 	elite_chance = 0
 	spd_bonus = 0
+	hp_bonus = 0
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:

--- a/brackey-game/goblin.gd
+++ b/brackey-game/goblin.gd
@@ -5,4 +5,5 @@ func _ready():
 	speed = 60
 	target = "Player"
 	tier = 1
+	droprate = 3
 	super() # Calls base class ready

--- a/brackey-game/main.gd
+++ b/brackey-game/main.gd
@@ -220,12 +220,16 @@ func _on_day_night_timer_is_daytime(is_day: Variant) -> void:
 		print("Mob spawn delay", $MobTimer.get_wait_time())
 		# They get faster over time
 		if Global.cycle_count >= 3:
+			# Bonus speed per day after 3
 			if Global.spd_bonus < 20:
-				Global.spd_bonus += 1
+				Global.spd_bonus += 2
 			if Global.elite_chance == 0:
-				Global.elite_chance = 25
+				Global.elite_chance = 20
 			elif Global.elite_chance < 50:
-				Global.elite_chance += 5
+				Global.elite_chance += 3
+			Global.hp_bonus += 5 # No limit to hp gain
+			if Global.hp_bonus > 50: # After 10 days of this
+				Global.hp_bonus += 15 # Make it 20 after day 14
 		#print("cycle", Global.cycle_count)
 		if Global.cycle_count == 6: # ended day 7
 			$HUD.show_win()

--- a/brackey-game/main.gd
+++ b/brackey-game/main.gd
@@ -19,6 +19,7 @@ var goblin = preload("res://goblin.tscn")
 var easy = [skeleton, mushroom, wind, goblin]
 var med = [demon, genie, witch, skeleton, mushroom, wind, air, goblin]
 var hard = [demon, genie, witch, skeleton, mushroom, charge_enemy, wind, air, goblin]
+var tier2 = [demon, genie, witch, air]
 var enemy_list
 
 #var spawn_time = 2
@@ -183,13 +184,28 @@ func _on_mob_timer_timeout() -> void:
 				mob.elite()
 func spawn_boss(is_elite):
 	var boss = charge_enemy.instantiate()
+	add_child(boss)
 	if is_elite:
 		boss.elite()
 	var boss_spawn_location = $MobPath/MobSpawnLocation
 	boss_spawn_location.progress_ratio = randf()
 	boss.position = boss_spawn_location.position
 	boss.connect("enemy_died", _update_score)
-	add_child(boss)
+	
+func spawn_elite(elite_to_spawn):
+	var elite
+	if len(elite_to_spawn) > 1:
+		elite_to_spawn.shuffle()
+		elite = elite_to_spawn[0].instantiate()
+	else:
+		elite = elite_to_spawn.instantiate()
+	add_child(elite)
+	elite.elite()
+	var elite_spawn_location = $MobPath/MobSpawnLocation
+	elite_spawn_location.progress_ratio = randf()
+	elite.position = elite_spawn_location.position
+	elite.connect("enemy_died", _update_score)
+	
 # Signals true/false when day night changes
 func _on_day_night_timer_is_daytime(is_day: Variant) -> void:
 	if is_day: # Kill enemies, show day popup
@@ -206,17 +222,17 @@ func _on_day_night_timer_is_daytime(is_day: Variant) -> void:
 		enable_turret(Global.cycle_count)
 		# Make enemies harder
 		if Global.cycle_count == 0:
-			print("Medium enemies")
+			print("Medium enemies spawning")
 			enemy_list = med
 		elif Global.cycle_count == 2:
-			print("Hard enemies")
+			print("Hard enemies spawning")
 			enemy_list = hard
 		# Increase spawn rate
 		var spawn_delay = $MobTimer.get_wait_time() * 0.9
-		if spawn_delay >= 0.3:
+		if spawn_delay >= 0.3: # 
 			$MobTimer.set_wait_time(spawn_delay)
-		else:
-			$MobTimer.set_wait_time(1)
+		#else:
+			#$MobTimer.set_wait_time(1)
 		print("Mob spawn delay", $MobTimer.get_wait_time())
 		# They get faster over time
 		if Global.cycle_count >= 3:
@@ -227,9 +243,9 @@ func _on_day_night_timer_is_daytime(is_day: Variant) -> void:
 				Global.elite_chance = 20
 			elif Global.elite_chance < 50:
 				Global.elite_chance += 3
-			Global.hp_bonus += 5 # No limit to hp gain
-			if Global.hp_bonus > 50: # After 10 days of this
-				Global.hp_bonus += 15 # Make it 20 after day 14
+			Global.hp_bonus += 10 # No limit to hp gain
+			if Global.hp_bonus > 100: # After 10 days of this
+				Global.hp_bonus += 15 # Make it 25 after day 14
 		#print("cycle", Global.cycle_count)
 		if Global.cycle_count == 6: # ended day 7
 			$HUD.show_win()
@@ -244,9 +260,18 @@ func _on_day_night_timer_is_daytime(is_day: Variant) -> void:
 		for i in get_tree().get_nodes_in_group("items"):
 			i.queue_free()
 		# Spawn the boss on specific days. could add special FX or delay
+		if Global.cycle_count == 0:
+			pass
+			#spawn_elite(easy)
 		if Global.cycle_count == 2:
 			spawn_boss(false)
+		if Global.cycle_count == 3:
+			spawn_elite(easy)
+		if Global.cycle_count == 4:
+			spawn_elite(tier2)
 		if Global.cycle_count == 5:
+			spawn_boss(true)
+		if Global.cycle_count == 6:
 			spawn_boss(true)
 # Disable all turrets except turret 1.
 # Called on start of game

--- a/brackey-game/mushroom.gd
+++ b/brackey-game/mushroom.gd
@@ -6,4 +6,5 @@ func _ready() -> void:
 	speed = 30
 	target = "Player"
 	tier = 1
+	droprate = 3
 	super()

--- a/brackey-game/skeleton.gd
+++ b/brackey-game/skeleton.gd
@@ -7,4 +7,5 @@ func _ready() -> void:
 	speed = 50
 	target = "Core"
 	tier = 1
+	droprate = 3
 	super()

--- a/brackey-game/wind_enemy.gd
+++ b/brackey-game/wind_enemy.gd
@@ -5,4 +5,5 @@ func _ready():
 	speed = 80
 	target = "Core"
 	tier = 1
+	droprate = 3
 	super() # Calls base class ready

--- a/brackey-game/witch.gd
+++ b/brackey-game/witch.gd
@@ -3,9 +3,10 @@ extends "res://base_enemy.gd"
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	health = 40
-	speed = 70
+	health = 60
+	speed = 90
 	target = "Player"
 	drops = "yellow"
 	tier = 2
+	droprate = 2
 	super()


### PR DESCRIPTION
Cycle scaling (Starts on day 4)

- Speed increased by 2 (from 1) per day up to 20
- Health increased by 10 per day. After day 14 it is increased by 25 instead.
- Elite chance starts at 20 (from 25) and increased by 3 (from 5), up to 50. 

Elite scaling (big mobs)
- Health multiplied by 8 (from 5)
- Speed bonus changed to +25% (from + 10)

Enemy changes
- Tier 1 monsters have 1/3 chance to drop
- Tier 2 have 1/2
- Elites and tier 3 always drop
- Tier 2 mobs buffed hp and speed
- Bull speed increased to 40, hp to 800 (from 30/600)
- Bull charge duration increased to 0.4 (from 0.33)
- Bull charge cooldown increased to 4 (from 3)
- Bull hitbox reduced
- Elite bull charge radius reverted to normal

Cycle rebalance
1. Tier 1 enemies spawn
2. Tier 1 and 2 enemies spawn
3. Bull appears
4. Bulls can spawn. Tier 1's can be elite (one always spawns)
5. Tier 2 elites can spawn (one always spawns)
6. Elite bull spawns
7. Elite bull spawns. Elite bulls added to spawn pool


